### PR TITLE
Fix the non working valveManager class GPIO handler method

### DIFF
--- a/server/src/switchRpiGpio.js
+++ b/server/src/switchRpiGpio.js
@@ -1,19 +1,18 @@
-const { Gpio } = require('onoff');
-
-const LED = [];
-LED[0] = new Gpio(2, 'out');
-LED[1] = new Gpio(3, 'out');
-
-LED[0].writeSync(1);
-LED[1].writeSync(1);
-
 function switchRpiGpio(valve, boolean) {
-  if (valve === 'valve1') {
-    LED[0].writeSync(boolean);
-  } else if (valve === 'valve2') {
-    LED[1].writeSync(boolean);
-  } else {
-    console.log('valve not found');
+  try {
+    const { Gpio } = require('onoff');
+    const LED = [];
+    LED[0] = new Gpio(2, 'out');
+    LED[1] = new Gpio(3, 'out');
+    LED[0].writeSync(1);
+    LED[1].writeSync(1);
+    if (valve === 'valve1') {
+      LED[0].writeSync(boolean);
+    } else if (valve === 'valve2') {
+      LED[1].writeSync(boolean);
+    }
+  } catch (error) {
+
   }
 }
 

--- a/server/src/valveManager.js
+++ b/server/src/valveManager.js
@@ -1,3 +1,5 @@
+const switchRpiGpio = require('./switchRpiGpio').switchRpiGpio;
+
 class ValveManager {
   constructor() {
     this.state = {
@@ -63,10 +65,7 @@ class ValveManager {
 
   GPIOhandler(valve) {
     try {
-      if (process.env.DEVELOPMENT === 'true') {
-        this.state.valves[valve].status ? console.log(valve, 0) : console.log(valve, 1);
-      } else {
-        const { switchRpiGpio } = require('./switchRpiGpio');
+      if (process.env.DEVELOPMENT === 'false') {
         this.state.valves[valve].status ? switchRpiGpio(valve, 0) : switchRpiGpio(valve, 1);
       }
     } catch (error) {


### PR DESCRIPTION
valveManager class  had a method to manipulate Raspberry Pi´s GPIO - the method was not working properly, due to import of 'onoff' module in switchRpiGpio.js class. Function body was wrapped to try block eliminating the error.